### PR TITLE
Rename only active attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ After processing, the filenames look something like this: 5be2a494d8c98092d80371
 
 This approach to naming attachments will add a bit of consistency to your notes. You might want to use this plugin in conjunction with [Consistent attachments and links](https://github.com/derwish-pro/obsidian-consistent-attachments-and-links) plugin.
 
-After renaming the files, the plugin updates the links in all notes that used these files.
+After using **"Rename all attachments"** the plugin updates the links in all notes that used these files. Alternatively you can use **''Rename only active attachments''** to rename attachments linked only to the current active MD file.
 
 This plugin can also delete duplicates (files that have the same content) if they are in the same folder. This will make your vault a little cleaner.
 
 In the settings there is also an option **"Rename only linked attachments"**. If it is enabled, you can be sure that the plugin renames only those files that are referenced in the notes in the standard markdown format. So, if no note is referenced to the file, or refers to it in wikilink format, then this file will be ignored.
 
-**The plugin is only compatible with standard markdown links. Wikilinks are not supported. You can convert all wikilinks to markdown links with [Consistent attachments and links](https://github.com/derwish-pro/obsidian-consistent-attachments-and-links) plugin.**
+**The "Rename all attachments" command is only compatible with standard markdown links (`![](../attachments/title.png)`). Wikilinks are not supported. You can convert all wikilinks to markdown links with [Consistent attachments and links](https://github.com/derwish-pro/obsidian-consistent-attachments-and-links) plugin. ''Rename only active attachments'' command works with all kind of links and generate links based on your preferences.**
 
 ## How to configure
 
-Assign a hotkey to **"Unique attachments: Rename all attachments"** command in the Obsidian Hotkeys settings.
+Assign a hotkey to **"Unique attachments: Rename all attachments"** and/or **"Unique attachments: Rename only active attachments" commands in the Obsidian Hotkeys settings.
 
 In the plugin settings, you can set the type of attachments that will be processed. Or you can ignore some folders that you don't want to process.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, TAbstractFile, TFile, EmbedCache, LinkCache, Notice } from 'obsidian';
+import { App, Plugin, TAbstractFile, TFile, EmbedCache, LinkCache, Notice, MarkdownView, getLinkpath } from 'obsidian';
 import { PluginSettings, DEFAULT_SETTINGS, SettingTab } from './settings';
 import { LinksHandler, LinkChangeInfo } from './links-handler';
 import { path } from './path';
@@ -23,6 +23,12 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 			callback: () => this.renameAllAttachments()
 		});
 
+		this.addCommand({
+			id: 'rename-only-active-attachments',
+			name: 'Rename only active attachments',
+			callback: () => this.renameOnlyActiveAttachments()
+		});
+
 
 		this.lh = new LinksHandler(this.app, "Unique attachments: ");
 	}
@@ -34,6 +40,32 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 
 		for (let file of files) {
 			let renamed = await this.renameAttachmentIfNeeded(file);
+			if (renamed)
+				renamedCount++;
+		}
+
+		if (renamedCount == 0)
+			new Notice("No files found that need to be renamed");
+		else if (renamedCount == 1)
+			new Notice("Renamed 1 file.");
+		else
+			new Notice("Renamed " + renamedCount + " files.");
+	}
+
+
+	async renameOnlyActiveAttachments() {
+		let mdfile = this.app.workspace.getActiveFile();
+
+		// check if the active file is the Markdown file
+		if (!mdfile.path.endsWith(".md")) {
+			return;
+		}
+		
+		let rlinks = Object.keys(this.app.metadataCache.resolvedLinks[mdfile.path]);
+		let renamedCount = 0;
+
+		for (let rlink of rlinks) {
+			let renamed = await this.renameAttachmentForActiveMD(rlink, mdfile);
 			if (renamed)
 				renamedCount++;
 		}
@@ -111,6 +143,106 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 				for (let note of notes) {
 					await this.lh.updateChangedPathInNote(note, filePath, validPath);
 				}
+			}
+
+			console.log("Unique attachments: file renamed [from, to]:\n   " + filePath + "\n   " + validPath);
+		}
+
+		return true;
+	}
+
+	// just rename the files and let Obsidian to update the links
+	async renameAttachmentForActiveMD(rlink: string, mdfile: TFile): Promise<boolean> {
+		let file = this.app.vault.getAbstractFileByPath(rlink)
+		let filePath = file.path;
+		if (this.checkFilePathIsIgnored(filePath) || !this.checkFileTypeIsAllowed(filePath)) {
+			return false;
+		}
+
+		let ext = path.extname(filePath);
+		let baseName = path.basename(filePath, ext);
+		let validBaseName = await this.generateValidBaseName(filePath);
+		if (baseName == validBaseName) {
+			return false;
+		}
+
+		// save the previous file name
+		let actMetadataCache = this.app.metadataCache.getFileCache(mdfile);
+		let currentView = this.app.workspace.activeLeaf.view as MarkdownView;
+		let cmDoc = currentView.sourceMode.cmEditor;
+		if (actMetadataCache.links) {
+			for (let eachLink of actMetadataCache.links) {
+				if (eachLink.link != eachLink.displayText) {
+					continue;
+				}
+				let afile = this.app.metadataCache.getFirstLinkpathDest(getLinkpath(eachLink.link), mdfile.path);
+				if (afile != null && afile.path == file.path) {
+					let newlink = this.app.fileManager.generateMarkdownLink(afile, file.parent.path, "", baseName);
+					// remove symbol '!'
+					newlink = newlink.substring(1);
+					const linkstart = eachLink.position.start;
+					const linkend = eachLink.position.end;
+					cmDoc.replaceRange(newlink, 
+							   {line: linkstart.line, ch: linkstart.col},
+							   {line: linkend.line, ch: linkend.col});
+					currentView.save();
+				}
+			}
+		}
+		if (actMetadataCache.embeds) {
+			for (let eachLink of actMetadataCache.embeds) {
+				if (eachLink.link != eachLink.displayText) {
+					continue;
+				}
+				let afile = this.app.metadataCache.getFirstLinkpathDest(getLinkpath(eachLink.link), mdfile.path);
+				if (afile != null && afile.path == file.path) {
+					let newlink = this.app.fileManager.generateMarkdownLink(afile, file.parent.path, "", baseName);
+					const linkstart = eachLink.position.start;
+					const linkend = eachLink.position.end;
+					cmDoc.replaceRange(newlink, 
+							   {line: linkstart.line, ch: linkstart.col},
+							   {line: linkend.line, ch: linkend.col});
+					currentView.save();
+				}
+			}
+		}
+
+		let validPath = this.lh.getFilePathWithRenamedBaseName(filePath, validBaseName);
+
+		let targetFileAlreadyExists = await this.app.vault.adapter.exists(validPath)
+
+		if (targetFileAlreadyExists) {
+			//if file content is the same in both files, one of them will be deleted			
+			let validAnotherFileBaseName = await this.generateValidBaseName(validPath);
+			if (validAnotherFileBaseName != validBaseName) {
+				console.warn("Unique attachments: cant rename file \n   " + filePath + "\n    to\n   " + validPath + "\n   Another file exists with the same (target) name but different content.")
+				return false;
+			}
+
+			if (!this.settings.mergeTheSameAttachments) {
+				console.warn("Unique attachments: cant rename file \n   " + filePath + "\n    to\n   " + validPath + "\n   Another file exists with the same (target) name and the same content. You can enable \"Delte duplicates\" setting for delete this file and merge attachments.")
+				return false;
+			}
+
+			try {
+				// Obsidian can not replace one file to another
+				let oldfile = this.app.vault.getAbstractFileByPath(validPath)
+				// so just silently delete the old file 
+				await this.app.vault.delete(oldfile);
+				// and give the same name to the new one
+				await this.app.fileManager.renameFile(file, validPath);
+			} catch (e) {
+				console.error("Unique attachments: cant delete duplicate file " + filePath + ".\n" + e);
+				return false;
+			}
+
+			console.log("Unique attachments: file content is the same in \n   " + filePath + "\n   and \n   " + validPath + "\n   Duplicates merged.")
+		} else {
+			try {
+				await this.app.fileManager.renameFile(file, validPath);
+			} catch (e) {
+				console.error("Unique attachments: cant rename file \n   " + filePath + "\n   to \n   " + validPath + "   \n" + e);
+				return false;
 			}
 
 			console.log("Unique attachments: file renamed [from, to]:\n   " + filePath + "\n   " + validPath);

--- a/src/main.ts
+++ b/src/main.ts
@@ -167,42 +167,27 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 		}
 
 		// save the previous file name
-		let actMetadataCache = this.app.metadataCache.getFileCache(mdfile);
-		let currentView = this.app.workspace.activeLeaf.view as MarkdownView;
-		let cmDoc = currentView.sourceMode.cmEditor;
-		if (actMetadataCache.links) {
-			for (let eachLink of actMetadataCache.links) {
-				if (eachLink.link != eachLink.displayText) {
-					continue;
-				}
-				let afile = this.app.metadataCache.getFirstLinkpathDest(getLinkpath(eachLink.link), mdfile.path);
-				if (afile != null && afile.path == file.path) {
-					let newlink = this.app.fileManager.generateMarkdownLink(afile, file.parent.path, "", baseName);
-					// remove symbol '!'
-					newlink = newlink.substring(1);
-					const linkstart = eachLink.position.start;
-					const linkend = eachLink.position.end;
-					cmDoc.replaceRange(newlink, 
-							   {line: linkstart.line, ch: linkstart.col},
-							   {line: linkend.line, ch: linkend.col});
-					currentView.save();
-				}
-			}
-		}
-		if (actMetadataCache.embeds) {
-			for (let eachLink of actMetadataCache.embeds) {
-				if (eachLink.link != eachLink.displayText) {
-					continue;
-				}
-				let afile = this.app.metadataCache.getFirstLinkpathDest(getLinkpath(eachLink.link), mdfile.path);
-				if (afile != null && afile.path == file.path) {
-					let newlink = this.app.fileManager.generateMarkdownLink(afile, file.parent.path, "", baseName);
-					const linkstart = eachLink.position.start;
-					const linkend = eachLink.position.end;
-					cmDoc.replaceRange(newlink, 
-							   {line: linkstart.line, ch: linkstart.col},
-							   {line: linkend.line, ch: linkend.col});
-					currentView.save();
+		if (this.settings.savePreviousName) {
+			let actMetadataCache = this.app.metadataCache.getFileCache(mdfile);
+			let currentView = this.app.workspace.activeLeaf.view as MarkdownView;
+			let cmDoc = currentView.sourceMode.cmEditor;
+			if (actMetadataCache.links) {
+				for (let eachLink of actMetadataCache.links) {
+					if (eachLink.link != eachLink.displayText) {
+						continue;
+					}
+					let afile = this.app.metadataCache.getFirstLinkpathDest(getLinkpath(eachLink.link), mdfile.path);
+					if (afile != null && afile.path == file.path) {
+						let newlink = this.app.fileManager.generateMarkdownLink(afile, file.parent.path, "", baseName);
+						// remove symbol '!'
+						newlink = newlink.substring(1);
+						const linkstart = eachLink.position.start;
+						const linkend = eachLink.position.end;
+						cmDoc.replaceRange(newlink, 
+								   {line: linkstart.line, ch: linkstart.col},
+								   {line: linkend.line, ch: linkend.col});
+						currentView.save();
+					}
 				}
 			}
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, TAbstractFile, TFile, EmbedCache, LinkCache, Notice, MarkdownView, getLinkpath } from 'obsidian';
+import { App, Plugin, TAbstractFile, TFile, EmbedCache, LinkCache, Notice, MarkdownView, getLinkpath, CachedMetadata } from 'obsidian';
 import { PluginSettings, DEFAULT_SETTINGS, SettingTab } from './settings';
 import { LinksHandler, LinkChangeInfo } from './links-handler';
 import { path } from './path';
@@ -60,16 +60,9 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 		if (!mdfile.path.endsWith(".md")) {
 			return;
 		}
+			
+		let renamedCount = await this.renameAttachmentsForActiveMD(mdfile);
 		
-		let rlinks = Object.keys(this.app.metadataCache.resolvedLinks[mdfile.path]);
-		let renamedCount = 0;
-
-		for (let rlink of rlinks) {
-			let renamed = await this.renameAttachmentForActiveMD(rlink, mdfile);
-			if (renamed)
-				renamedCount++;
-		}
-
 		if (renamedCount == 0)
 			new Notice("No files found that need to be renamed");
 		else if (renamedCount == 1)
@@ -152,47 +145,69 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 	}
 
 	// just rename the files and let Obsidian to update the links
-	async renameAttachmentForActiveMD(rlink: string, mdfile: TFile): Promise<boolean> {
-		let file = this.app.vault.getAbstractFileByPath(rlink)
-		let filePath = file.path;
-		if (this.checkFilePathIsIgnored(filePath) || !this.checkFileTypeIsAllowed(filePath)) {
-			return false;
+	async renameAttachmentsForActiveMD(mdfile: TFile): Promise<number> {
+
+		let rlinks = Object.keys(this.app.metadataCache.resolvedLinks[mdfile.path]);
+		let renamedCount = 0;
+		
+		let actMetadataCache = this.app.metadataCache.getFileCache(mdfile);
+		let currentView = this.app.workspace.activeLeaf.view as MarkdownView;
+
+		for (let rlink of rlinks) {
+			let file = this.app.vault.getAbstractFileByPath(rlink)
+			let filePath = file.path;
+			if (this.checkFilePathIsIgnored(filePath) || !this.checkFileTypeIsAllowed(filePath)) {
+				continue;
+			}
+
+			let ext = path.extname(filePath);
+			let baseName = path.basename(filePath, ext);
+			let validBaseName = await this.generateValidBaseName(filePath);
+			if (baseName == validBaseName) {
+				continue;
+			}
+
+			if (this.settings.savePreviousName) {
+				this.saveAttachmentNameInLink(actMetadataCache, mdfile, file, baseName, currentView);
+			}
+			currentView.save();
+
+			if (!this.renameAttachment(file, validBaseName)) {
+				continue;
+			}
+			renamedCount++;
 		}
 
-		let ext = path.extname(filePath);
-		let baseName = path.basename(filePath, ext);
-		let validBaseName = await this.generateValidBaseName(filePath);
-		if (baseName == validBaseName) {
-			return false;
+		return renamedCount;
+	}
+	
+	saveAttachmentNameInLink(mdc: CachedMetadata, mdfile: TFile, file: TAbstractFile, baseName: string, currentView: MarkdownView) {
+		let cmDoc = currentView.sourceMode.cmEditor;
+		if (!mdc.links) {
+			return;
 		}
 
-		// save the previous file name
-		if (this.settings.savePreviousName) {
-			let actMetadataCache = this.app.metadataCache.getFileCache(mdfile);
-			let currentView = this.app.workspace.activeLeaf.view as MarkdownView;
-			let cmDoc = currentView.sourceMode.cmEditor;
-			if (actMetadataCache.links) {
-				for (let eachLink of actMetadataCache.links) {
-					if (eachLink.link != eachLink.displayText) {
-						continue;
-					}
-					let afile = this.app.metadataCache.getFirstLinkpathDest(getLinkpath(eachLink.link), mdfile.path);
-					if (afile != null && afile.path == file.path) {
-						let newlink = this.app.fileManager.generateMarkdownLink(afile, file.parent.path, "", baseName);
-						// remove symbol '!'
-						newlink = newlink.substring(1);
-						const linkstart = eachLink.position.start;
-						const linkend = eachLink.position.end;
-						cmDoc.replaceRange(newlink, 
-								   {line: linkstart.line, ch: linkstart.col},
-								   {line: linkend.line, ch: linkend.col});
-						currentView.save();
-					}
-				}
+		for (let eachLink of mdc.links) {
+			if (eachLink.displayText != "" && eachLink.link != eachLink.displayText) {
+				continue;
+			}
+			let afile = this.app.metadataCache.getFirstLinkpathDest(getLinkpath(eachLink.link), mdfile.path);
+			if (afile != null && afile.path == file.path) {
+				let newlink = this.app.fileManager.generateMarkdownLink(afile, file.parent.path, "", baseName);
+				// remove symbol '!'
+				newlink = newlink.substring(1);
+				const linkstart = eachLink.position.start;
+				const linkend = eachLink.position.end;
+				cmDoc.replaceRange(newlink, 
+						   {line: linkstart.line, ch: linkstart.col},
+						   {line: linkend.line, ch: linkend.col});
 			}
 		}
+	}
 
-		let validPath = this.lh.getFilePathWithRenamedBaseName(filePath, validBaseName);
+	async renameAttachment(file: TAbstractFile, validBaseName: string): Promise<boolean> {
+
+		let validPath = this.lh.getFilePathWithRenamedBaseName(file.path, validBaseName);
 
 		let targetFileAlreadyExists = await this.app.vault.adapter.exists(validPath)
 
@@ -200,12 +215,12 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 			//if file content is the same in both files, one of them will be deleted			
 			let validAnotherFileBaseName = await this.generateValidBaseName(validPath);
 			if (validAnotherFileBaseName != validBaseName) {
-				console.warn("Unique attachments: cant rename file \n   " + filePath + "\n    to\n   " + validPath + "\n   Another file exists with the same (target) name but different content.")
+				console.warn("Unique attachments: cant rename file \n   " + file.path + "\n    to\n   " + validPath + "\n   Another file exists with the same (target) name but different content.")
 				return false;
 			}
 
 			if (!this.settings.mergeTheSameAttachments) {
-				console.warn("Unique attachments: cant rename file \n   " + filePath + "\n    to\n   " + validPath + "\n   Another file exists with the same (target) name and the same content. You can enable \"Delte duplicates\" setting for delete this file and merge attachments.")
+				console.warn("Unique attachments: cant rename file \n   " + file.path + "\n    to\n   " + validPath + "\n   Another file exists with the same (target) name and the same content. You can enable \"Delte duplicates\" setting for delete this file and merge attachments.")
 				return false;
 			}
 
@@ -217,22 +232,21 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 				// and give the same name to the new one
 				await this.app.fileManager.renameFile(file, validPath);
 			} catch (e) {
-				console.error("Unique attachments: cant delete duplicate file " + filePath + ".\n" + e);
+				console.error("Unique attachments: cant delete duplicate file " + file.path + ".\n" + e);
 				return false;
 			}
 
-			console.log("Unique attachments: file content is the same in \n   " + filePath + "\n   and \n   " + validPath + "\n   Duplicates merged.")
+			console.log("Unique attachments: file content is the same in \n   " + file.path + "\n   and \n   " + validPath + "\n   Duplicates merged.")
 		} else {
 			try {
 				await this.app.fileManager.renameFile(file, validPath);
 			} catch (e) {
-				console.error("Unique attachments: cant rename file \n   " + filePath + "\n   to \n   " + validPath + "   \n" + e);
+				console.error("Unique attachments: cant rename file \n   " + file.path + "\n   to \n   " + validPath + "   \n" + e);
 				return false;
 			}
 
-			console.log("Unique attachments: file renamed [from, to]:\n   " + filePath + "\n   " + validPath);
+			console.log("Unique attachments: file renamed [from, to]:\n   " + file.path + "\n   " + validPath);
 		}
-
 		return true;
 	}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ export interface PluginSettings {
     renameFileTypes: string[];
     renameOnlyLinkedAttachments: boolean,
     mergeTheSameAttachments: boolean,
+    savePreviousName: boolean,
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
@@ -13,6 +14,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
     renameFileTypes: ["png", "jpg", "gif"],
     renameOnlyLinkedAttachments: true,
     mergeTheSameAttachments: true,
+    savePreviousName: false,
 }
 
 export class SettingTab extends PluginSettingTab {
@@ -64,6 +66,15 @@ export class SettingTab extends PluginSettingTab {
                 this.plugin.saveSettings();
             }
             ).setValue(this.plugin.settings.renameOnlyLinkedAttachments));
+
+	new Setting(containerEl)
+            .setName('Save a previous name')
+            .setDesc('Save a previous name of an attachment in the link. Works with rename-Only-Active-Attachments command.')
+            .addToggle(cb => cb.onChange(value => {
+                this.plugin.settings.savePreviousName = value;
+                this.plugin.saveSettings();
+            }
+            ).setValue(this.plugin.settings.savePreviousName));
 
         new Setting(containerEl)
             .setName('Delete duplicates')


### PR DESCRIPTION
I've add the new command to work only with the current markdown file. I used API to get and update links, so it can be used without _Consistent attachments and links_ plugin.