### PR TITLE
Fix mobile support on Android + Fix build with current Obsidian API

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -182,7 +182,7 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 	}
 	
 	saveAttachmentNameInLink(mdc: CachedMetadata, mdfile: TFile, file: TAbstractFile, baseName: string, currentView: MarkdownView) {
-		let cmDoc = currentView.sourceMode.cmEditor;
+		let cmDoc = currentView.editor;
 		if (!mdc.links) {
 			return;
 		}
@@ -295,7 +295,3 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 
 
 }
-
-
-
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -272,7 +272,7 @@ export default class ConsistentAttachmentsAndLinks extends Plugin {
 	async generateValidBaseName(filePath: string) {
 		let file = this.lh.getFileByPath(filePath);
 		let data = await this.app.vault.readBinary(file);
-		const buf = Buffer.from(data);
+		const buf = new Uint8Array(data);
 
 		// var crypto = require('crypto');
 		// let hash: string = crypto.createHash('md5').update(buf).digest("hex");


### PR DESCRIPTION
The two commits in this pull request do the following:

1. The first replaces the `sourceMode.cmEditor` MarkdownView property with the `editor` property. This allows the plugin to build with the current version of the Obsidian API.
2. The second replaces `Buffer.from()` with `new Uint8Array()` (blatantly stolen from [this fix for the Better PDF plugin](https://github.com/MSzturc/obsidian-better-pdf-plugin/pull/38/commits/8bcfbd18204d17249bbb3376698faef861cbc2e5)). This enables the plugin to work on the *Android* mobile app.

I have tested these changes on macOS (Obsidian desktop) and Android (Obsidian mobile). I do *not* have an iOS device to test anymore, but presumably it should work there as well (modulo [whether this older iOS issue](https://github.com/dy-sh/obsidian-unique-attachments/issues/11) is still applicable).